### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @tomoish
-* @kou7306
-* @Hayatto9217
-* @shiori-42
+* @tomoish @kou7306 @Hayatto9217 @shiori-42


### PR DESCRIPTION
* Fix ./github/CODEOWNERS due to add ALL codeowneres in Reviewers list automatically.